### PR TITLE
feat: Add configurable OpenAI base URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,9 @@ TRANSCRIPTION_PROVIDER=openai
 # OpenAI API Configuration (required when using OpenAI provider)
 OPENAI_API_KEY=sk-your-openai-api-key-here
 
+# OpenAI Base URL (optional - for custom API endpoints)
+#OPENAI_BASE_URL=https://api.openai.com/v1
+
 # Audio Feedback Configuration (optional - defaults shown)
 ENABLE_AUDIO_FEEDBACK=true
 BEEP_VOLUME=0.1

--- a/src/transcription/mod.rs
+++ b/src/transcription/mod.rs
@@ -113,7 +113,7 @@ impl TranscriptionFactory {
                     Some(config.whisper_timeout_seconds),
                     Some(config.whisper_max_retries),
                     Some(config.whisper_model),
-                    None,
+                    config.openai_base_url,
                 )?;
 
                 Ok(Box::new(client))


### PR DESCRIPTION
This PR introduces the ability to configure the OpenAI API base URL via the OPENAI_BASE_URL environment variable, and adds a shell.nix for NixOS users.