### PR TITLE
feature: added downloading progress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2659,7 +2659,7 @@ dependencies = [
 
 [[package]]
 name = "waystt"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
## Summary
Brief description of the changes in this PR.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Changes Made
- `download_model` modified to show download % and MB/S 


## Testing
- [x] Tests pass locally with `cargo test`
- [x] Code follows the project's style guidelines (`cargo fmt` and `cargo clippy`)
- [ ] Self-review of the code has been performed
- [ ] Code has been tested manually (if applicable)

### Test Environment
- OS: [e.g. Arch Linux]
- Wayland Compositor: [e.g. Hyprland]
- Audio System: [e.g. PipeWire]

## Additional Notes
As any line replacing cli thing, it breaks if the terminal is is narrower than the printed line.
You can solve this by using [terminal_size](https://crates.io/crates/terminal_size), but didn't think another dependency.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes